### PR TITLE
pause autoRotate during user interaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ module.exports = function(THREE) {
 
             phi = Math.atan2( Math.sqrt( offset.x * offset.x + offset.z * offset.z ), offset.y );
 
-            if ( this.autoRotate ) {
+            if ( this.autoRotate && state === STATE.NONE ) {
 
                 this.rotateLeft( getAutoRotationAngle() );
 


### PR DESCRIPTION
merged c04c72c 'OrbitControls: pause autoRotate during user interaction' ... by chrmoritz from the three repository.

It does what it says. Before the camera would rotate under the clicked cursor. Now it stops the auto rotation.
