### PR TITLE
Remove comment from onMouseUp parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ module.exports = function(THREE) {
 
         }
 
-        function onMouseUp( /* event */ ) {
+        function onMouseUp( event ) {
 
             if ( scope.enabled === false ) return;
 


### PR DESCRIPTION
Having a comment in the onMouseUp parameter in Firefox (34.0.5) causes the canvas to rotate wildly on subsequent touches after the first onMouseDown is called.  It seems like onMouseUp isn't being properly called and so the controls aren't reset properly.  Either moving the comment to above the function or leaving the event parameter without a comment seems like a good fix.
