### PR TITLE
Ties event handling to scope.domElement only

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,10 +219,10 @@ module.exports = function( THREE ) {
 			scope.domElement.removeEventListener( 'touchend', onTouchEnd, false );
 			scope.domElement.removeEventListener( 'touchmove', onTouchMove, false );
 
-			document.removeEventListener( 'mousemove', onMouseMove, false );
-			document.removeEventListener( 'mouseup', onMouseUp, false );
+			scope.domElement.removeEventListener( 'mousemove', onMouseMove, false );
+			scope.domElement.removeEventListener( 'mouseup', onMouseUp, false );
 
-			window.removeEventListener( 'keydown', onKeyDown, false );
+			scope.domElement.removeEventListener( 'keydown', onKeyDown, false );
 
 			//scope.dispatchEvent( { type: 'dispose' } ); // should this be added here?
 
@@ -880,7 +880,7 @@ module.exports = function( THREE ) {
 		scope.domElement.addEventListener( 'touchend', onTouchEnd, false );
 		scope.domElement.addEventListener( 'touchmove', onTouchMove, false );
 
-		window.addEventListener( 'keydown', onKeyDown, false );
+		scope.domElement.addEventListener( 'keydown', onKeyDown, false );
 
 		// force an update at start
 


### PR DESCRIPTION
`OrbitControls` globally listens to `mousemove`, `mouseup` and `keydown` events. That means that even if an`<input>` element exists outside of the OrbitControls, moving the text cursor with the key arrows within this `<input>` will pan the OrbitControls.

This PR ensures that only scope key / mouse events are processed by the `OrbitControls`.