### PR TITLE
Add user interaction events logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 *.log
 .DS_Store
 bundle.js
+
+// JetBrains IDEs settings
+.idea/

--- a/index.js
+++ b/index.js
@@ -81,6 +81,11 @@ module.exports = function( THREE ) {
 		this.position0 = this.object.position.clone();
 		this.zoom0 = this.object.zoom;
 
+		// For user interaction events
+		this.interactionEventStarted = false;
+		this.interactionEventStartedTimeout = null;
+		this.interactionEventStartedTimeoutInterval = 0;
+
 		//
 		// public methods
 		//
@@ -237,6 +242,35 @@ module.exports = function( THREE ) {
 		var changeEvent = { type: 'change' };
 		var startEvent = { type: 'start' };
 		var endEvent = { type: 'end' };
+
+		var interactionStartEvent = { type: 'interactionStart' };
+		var interactionEndEvent = { type: 'interactionEnd' };
+
+		function handleInteractionEventStart() {
+			if (scope.interactionEventStarted === false) {
+				scope.interactionEventStarted = true;
+				scope.dispatchEvent(interactionStartEvent);
+			}
+		}
+
+		function handleInteractionEventEnd() {
+			if (scope.interactionEventStarted === true) {
+				if (scope.interactionEventStartedTimeout !== null && scope.interactionEventStartedTimeout >= 0) {
+					clearTimeout(scope.interactionEventStartedTimeout);
+					scope.interactionEventStartedTimeout = null;
+				}
+
+				scope.interactionEventStartedTimeout = setTimeout(function() {
+					scope.interactionEventStarted = false;
+					scope.dispatchEvent( interactionEndEvent );
+				}, scope.interactionEventStartedTimeoutInterval);
+			}
+		}
+
+		function handleInteractionEvent() {
+			handleInteractionEventStart();
+			handleInteractionEventEnd();
+		}
 
 		var STATE = { NONE : - 1, ROTATE : 0, DOLLY : 1, PAN : 2, TOUCH_ROTATE : 3, TOUCH_DOLLY : 4, TOUCH_PAN : 5 };
 
@@ -448,6 +482,8 @@ module.exports = function( THREE ) {
 
 			scope.update();
 
+			handleInteractionEventStart();
+
 		}
 
 		function handleMouseMoveDolly( event ) {
@@ -472,6 +508,8 @@ module.exports = function( THREE ) {
 
 			scope.update();
 
+			handleInteractionEventStart();
+
 		}
 
 		function handleMouseMovePan( event ) {
@@ -488,11 +526,15 @@ module.exports = function( THREE ) {
 
 			scope.update();
 
+			handleInteractionEventStart()
+
 		}
 
 		function handleMouseUp( event ) {
 
 			//console.log( 'handleMouseUp' );
+
+			handleInteractionEventEnd()
 
 		}
 
@@ -511,6 +553,8 @@ module.exports = function( THREE ) {
 			}
 
 			scope.update();
+
+			handleInteractionEvent();
 
 		}
 
@@ -592,6 +636,8 @@ module.exports = function( THREE ) {
 
 			scope.update();
 
+			handleInteractionEventStart()
+
 		}
 
 		function handleTouchMoveDolly( event ) {
@@ -621,6 +667,8 @@ module.exports = function( THREE ) {
 
 			scope.update();
 
+			handleInteractionEventStart();
+
 		}
 
 		function handleTouchMovePan( event ) {
@@ -637,11 +685,15 @@ module.exports = function( THREE ) {
 
 			scope.update();
 
+			handleInteractionEventEnd();
+
 		}
 
 		function handleTouchEnd( event ) {
 
 			//console.log( 'handleTouchEnd' );
+
+			handleInteractionEventEnd();
 
 		}
 


### PR DESCRIPTION
Adds events that signify when the user has actually started interacting with the orbit controls, and when they have stopped.

For example: a mouse down event doesn't necessarily signify that the user has begun interacting with the controls. It could mean that the user has begun interacting with the canvas and has their own click logic in place. If they were to click on an intersected element, the controls would fire their start and end event. If the user were to click on an intersected element, and then drag the object to a new position, the click event would be fired on the element that was originally intersected. Having a way to differentiate between click and actual interaction, and a way to "delay" the end event is useful in these situations.